### PR TITLE
Fix Error on Ubuntu

### DIFF
--- a/Local/package.json
+++ b/Local/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "set NODE_ENV=development && set BABEL_ENV=development && webpack-dev-server --config webpack.config.dev.js --https false --open http://localhost:9999/index.html --watch",
-    "https": "set NODE_ENV=development && set BABEL_ENV=development && webpack-dev-server --config webpack.config.dev.js --https true --open https://localhost:9999/index.html --watch"
+    "start": "set NODE_ENV=development && set BABEL_ENV=development && webpack-dev-server --config webpack.config.dev.js --https false --watch",
+    "https": "set NODE_ENV=development && set BABEL_ENV=development && webpack-dev-server --config webpack.config.dev.js --https true --watch"
   },
   "keywords": [
     "zoom",


### PR DESCRIPTION
Running NPM start for the local version causes an error on Ubuntu. The following two posts on the Zoom developer form talk about this error:

1. https://devforum.zoom.us/t/installing-sample-app-web-gives-error/12103
2. https://devforum.zoom.us/t/unable-to-use-zoom-websdk-sample-web-app/15855

This change fixes that error. It will prevent the page from automatically opening in someone's browser. But Webpack already prints out a message saying `Project is running at https://localhost:9999`, so this doesn't seem like a big loss. 