### PR TITLE
Make regexp for numbers act globally for paste buffer

### DIFF
--- a/CDN/js/index.js
+++ b/CDN/js/index.js
@@ -60,7 +60,7 @@ function websdkready() {
   document
     .getElementById("meeting_number")
     .addEventListener("input", function (e) {
-      var tmpMn = e.target.value.replace(/([^0-9])+/i, "");
+      var tmpMn = e.target.value.replace(/([^0-9])+/ig, "");
       if (tmpMn.match(/([0-9]{9,11})/)) {
         tmpMn = tmpMn.match(/([0-9]{9,11})/)[1];
       }

--- a/Local/js/index.js
+++ b/Local/js/index.js
@@ -50,7 +50,7 @@ document.getElementById("meeting_lang").addEventListener("change", (e) => {
 document
   .getElementById("meeting_number")
   .addEventListener("input", function (e) {
-    let tmpMn = e.target.value.replace(/([^0-9])+/i, "");
+    let tmpMn = e.target.value.replace(/([^0-9])+/ig, "");
     if (tmpMn.match(/([0-9]{9,11})/)) {
       tmpMn = tmpMn.match(/([0-9]{9,11})/)[1];
     }


### PR DESCRIPTION
Given a paste buffer from zoom with meeting "123 456 789", the substitution regexp must be globally applied in order to remove all spaces.