### PR TITLE
Version bump websdk to 1.8.6

### DIFF
--- a/Local/package.json
+++ b/Local/package.json
@@ -19,7 +19,7 @@
   "author": "Jack Yang",
   "license": "ISC",
   "dependencies": {
-    "@zoomus/websdk": "^1.8.3",
+    "@zoomus/websdk": "^1.8.6",
     "lodash": "^4.17.14",
     "react": "16.8.6",
     "react-dom": "16.8.6",


### PR DESCRIPTION
[Per the Jan 10th Web SDK update](https://marketplace.zoom.us/docs/guides/stay-up-to-date/announcements#required-websdk-update), we must upgrade the [`websdk`](https://github.com/zoom/websdk) in order to support the AES 256-bit GCM encryption that allows us to join with computer audio